### PR TITLE
feat: allow configuration to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Changed
+
+- **BREAKING:** now able to override `telus-standard` configuration by supplying an
+  `.eslintrc.*` file. See
+  [eslint docs for vaild files](https://eslint.org/docs/user-guide/configuring#configuration-file-formats)
+  and [Pull Request #25 for why this is breaking](https://github.com/telus/telus-standard/pull/25)

--- a/README.md
+++ b/README.md
@@ -46,17 +46,12 @@ You can also add `telus-standard` to your **package.json** scripts:
      eslint-plugin-react
    ```
 
-2. Remove unnecessary files
-   ```sh
-   rm -v .eslint*
-   ```
-
-3. Install `telus-standard`
+2. Install `telus-standard`
    ```sh
    npm i --save-dev @telus/telus-standard
    ```
 
-4. Update or add the these scripts in your **package.json**
+3. Update or add the these scripts in your **package.json**
    ```json
    {
      "scripts": {
@@ -66,7 +61,7 @@ You can also add `telus-standard` to your **package.json** scripts:
    }
    ```
 
-5. Run the lint command
+4. Run the lint command
    ```sh
    npm run lint
    ```

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#! /usr/bin/env node
 const opts = require('../options')
 
 if (process.version.match(/v(\d+)\./)[1] < 6) {

--- a/options.js
+++ b/options.js
@@ -1,5 +1,4 @@
 const eslint = require('eslint')
-const path = require('path')
 const pkg = require('./package.json')
 
 module.exports = {
@@ -7,8 +6,8 @@ module.exports = {
   cmd: 'telus-standard',
   eslint,
   eslintConfig: {
-    configFile: path.join(__dirname, 'eslintrc.js'),
-    cache: false
+    baseConfig: require('./eslintrc'),
+    useEslintrc: true
   },
   homepage: pkg.homepage,
   tagline: 'Use TELUS JavaScript Standard Style',

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "telus-standard": "./bin/cmd.js"
   },
   "keywords": [
-    "telus",
-    ""
+    "telus"
   ],
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
![itshappening](https://user-images.githubusercontent.com/621541/71704880-a29e1b80-2d91-11ea-992c-42767802bc9e.gif)

This PR enables the (long awaited) ability to override the `telus-standard` linting configuration. For some users, this will be a **BREAKING** change.

## How do I know if this will be a breaking change for my project?

1. You have already migrated to `telus-standard`
1. Your project has a `.eslintrc.*` file

If you meet these criteria then when you upgrade to the latest version of `telus-standard`, your existing configuration may come into play and you _may_ fail linting.

## Please, how do I bring back semicolons?

If you don't have an [`.eslintrc.*` file](https://eslint.org/docs/user-guide/configuring#configuration-file-formats), create a new `.eslintrc.js` and add this:

```js
module.exports = {
  rules: {
    semi: ['error', 'always']
  }
}
```